### PR TITLE
Fix: Replace deprecated CARTO tile URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,8 +123,8 @@
                 isTransitioning = false;
             });
 
-            const tileLayer = L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
-                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+            const tileLayer = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+                attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, &copy; <a href="https://carto.com/attributions">CARTO</a>',
                 subdomains: 'abcd',
                 maxZoom: 20
             });


### PR DESCRIPTION
The map was not loading because the CARTO raster tile URL for the 'voyager' style is no longer operational.

This commit replaces the deprecated URL with the 'light_all' style URL, which is a supported alternative according to CARTO's documentation. The attribution string has also been updated to match the recommended format.